### PR TITLE
feat: enable changing temperature with on button when light is on

### DIFF
--- a/ikea_E1743-E2201-E2213_ZHA-Z2M_control-anything.yaml
+++ b/ikea_E1743-E2201-E2213_ZHA-Z2M_control-anything.yaml
@@ -314,6 +314,7 @@ variables:
   off_double_press_exposed: !input off_double_press_exposed
   remote_devices: !input remote_devices
   remote_devices_names: "{{ remote_devices | map('device_attr', 'name') | list }}"
+  zha_device_id: "{{ trigger.event.data.device_id if is_zha }}"
 condition:
   - condition: template
     value_template: >-
@@ -345,7 +346,7 @@ actions:
                           - trigger: event
                             event_type: zha_event
                             event_data:
-                              device_id: "{{ remote_device }}"
+                              device_id: "{{ zha_device_id }}"
                               command: "on"
                               cluster_id: 6
                               endpoint_id: 1
@@ -398,7 +399,7 @@ actions:
                           - trigger: event
                             event_type: zha_event
                             event_data:
-                              device_id: "{{ remote_device }}"
+                              device_id: "{{ zha_device_id }}"
                               command: "off"
                               cluster_id: 6
                               endpoint_id: 1
@@ -468,7 +469,7 @@ actions:
                                     - trigger: event
                                       event_type: zha_event
                                       event_data:
-                                        device_id: "{{ remote_device }}"
+                                        device_id: "{{ zha_device_id }}"
                                         command: "stop_with_on_off"
                                         cluster_id: 8
                                         endpoint_id: 1
@@ -526,7 +527,7 @@ actions:
                                     - trigger: event
                                       event_type: zha_event
                                       event_data:
-                                        device_id: "{{ remote_device }}"
+                                        device_id: "{{ zha_device_id }}"
                                         command: "stop_with_on_off"
                                         cluster_id: 8
                                         endpoint_id: 1

--- a/ikea_E1743-E2201-E2213_ZHA-Z2M_control-light-with-double-press.yaml
+++ b/ikea_E1743-E2201-E2213_ZHA-Z2M_control-light-with-double-press.yaml
@@ -1,0 +1,656 @@
+blueprint:
+  homeassistant:
+    min_version: 2024.10.0
+  author: damru
+  domain: automation
+  name: Ikea's Rodret, Somrig or Tradfri 💡 Light control
+  description: >
+    ## 💡 Control a light with **IKEA RODRET** or **IKEA SOMRIG** or **IKEA TRADFRI ON/OFF** remotes
+
+
+    Only for use with [ZHA](https://www.home-assistant.io/integrations/zha/)
+    or Zigbee2MQTT (cf [MQTT](https://www.home-assistant.io/integrations/mqtt)
+    + [Z2M addon](https://www.zigbee2mqtt.io/guide/installation/03_ha_addon.html)).
+
+
+    Available controls:
+
+    - Press **on** (Rodret, Tradfri) or **1 dot** (Somrig) to turn on the light
+    (Optional: set the target brightness by enabling **Force Brightness** and setting a **Brightness** value)
+
+    - Press **off** (Rodret, Tradfri) or **2 dots** (Somrig) to turn off the light
+
+    - Hold **on** (Rodret, Tradfri) or **1 dot** (Somrig) button to increase the brightness
+
+    - Hold **off** (Rodret, Tradfri) or **2 dots** (Somrig) button to decrease the brightness down to 1%
+
+    - Double press **on/off** (Rodret, Tradfri, _Optional_)  **1 dot/2 dots** (Somrig)
+  input:
+    remote_devices:
+      name: Remotes
+      description: >
+        IKEA remote (Rodret, Somrig, Tradfri) to use.
+      default: []
+      selector:
+        device:
+          filter:
+            - integration: zha
+              manufacturer: IKEA of Sweden
+              model: TRADFRI on/off switch
+            - integration: zha
+              manufacturer: IKEA of Sweden
+              model: RODRET Dimmer
+            - integration: zha
+              manufacturer: IKEA of Sweden
+              model: SOMRIG shortcut button
+            - integration: mqtt
+              manufacturer: IKEA
+              model: TRADFRI on/off switch
+            - integration: mqtt
+              manufacturer: IKEA
+              model: RODRET wireless dimmer/power switch
+            - integration: mqtt
+              manufacturer: IKEA
+              model: SOMRIG shortcut button
+            # DEPRECATED - for removal, keeping for z2m v1 backward compatibility
+            - integration: mqtt
+              manufacturer: IKEA
+              model: TRADFRI on/off switch (E1743)
+            # DEPRECATED - for removal, keeping for z2m v1 backward compatibility
+            - integration: mqtt
+              manufacturer: IKEA
+              model: RODRET wireless dimmer/power switch (E2201)
+            # DEPRECATED - for removal, keeping for z2m v1 backward compatibility
+            - integration: mqtt
+              manufacturer: IKEA
+              model: SOMRIG shortcut button (E2213)
+          multiple: true
+    light:
+      name: Light
+      description: Light to control
+      selector:
+        entity:
+          filter:
+            domain: light
+          multiple: false
+    brightness_section:
+      name: Brightness
+      icon: mdi:lightbulb-on-50
+      collapsed: true
+      input:
+        helper_force_brightness:
+          name: Force brightness
+          description: Force the brightness to **Brightness** value when light turns on.
+          default: false
+          selector:
+            boolean: {}
+        helper_brightness:
+          name: Brightness
+          description:
+            Target light brightness when turning on. Requires **Force brightness**
+            to be enabled.
+          default: 50
+          selector:
+            number:
+              unit_of_measurement: "%"
+              min: 1.0
+              max: 100.0
+              step: 1.0
+              mode: slider
+    temperature_section:
+      name: Colour temperature
+      icon: mdi:lightbulb-on-50
+      collapsed: true
+      input:
+        helper_max_temperature:
+          name: Max temperature
+          description: The maximum colour temperature before looping round to the minimum.
+          default: 450
+          selector:
+            number:
+              min: 1.0
+              max: 600.0
+              step: 1.0
+              mode: slider
+        helper_min_temperature:
+          name: Min temperature
+          description: The minimum colour temperature, set when the maximum has been reached and the temperature is changed.
+          default: 225
+          selector:
+            number:
+              min: 1.0
+              max: 600.0
+              step: 1.0
+              mode: slider
+        helper_temperature_change_step:
+          name: Temperature change step
+          description:
+            Step value to add to colour temperature for each change.
+          default: 75
+          selector:
+            number:
+              min: 1.0
+              max: 600.0
+              step: 1.0
+              mode: slider
+        helper_temperature_transition_time:
+          name: Temperature change transition time
+          description:
+            Number of seconds for temperature to transition over.
+          default: 0.5
+          selector:
+            number:
+              min: 0.0
+              max: 10.0
+              step: 0.1
+              mode: slider
+    on_double_press_action:
+      name: Double press "on / 1 dot" action
+      description: >
+        Choose action(s) to run when the **on** (Rodret, Tradfri) or **1 dot** (Somrig) button is **pressed twice**.
+
+        **_NB for Rodret, Tradfri only_**: **Double press event (on)** must be exposed and **Double press delay** interval is used as a timeout.
+      default: []
+      selector:
+        action: {}
+    off_double_press_action:
+      name: Double press "off / 2 dots" action
+      description: >
+        Choose action(s) to run when the **off** (Rodret, Tradfri) or **2 dots** (Somrig) button is **pressed twice**. 
+
+        **_NB for Rodret, Tradfri only_**: **Double press event (off)** must be exposed and **Double press delay** interval is used as a timeout.
+      default: []
+      selector:
+        action: {}
+    rodret_tradfri_options_section:
+      name: Rodret, Tradfri options
+      icon: mdi:remote
+      collapsed: true
+      input:
+        on_double_press_exposed:
+          name: Expose virtual double press "on" event
+          description: >
+            Choose whether or not to expose the virtual **double press** event for the **on** button. 
+            Turn this on if you are providing action(s) for the **Double press action (on / 1 dot)**.
+          default: false
+          selector:
+            boolean: {}
+        off_double_press_exposed:
+          name: Expose virtual double press "off" event
+          description: >
+            Choose whether or not to expose the virtual **double press** event for the **off** button. 
+            Turn this on if you are providing an action for the **Double press action (off / 2 dots)**.
+          default: false
+          selector:
+            boolean: {}
+        helper_double_press_delay:
+          name: Double press delay
+          description: >
+            Max delay between the first and the second button press for the
+            **Double press events**. Provide a value only if you are using a double press action.
+            Increase this value if you notice that the double press action is not triggered
+            properly.
+          default: 250
+          selector:
+            number:
+              unit_of_measurement: milliseconds
+              min: 100.0
+              max: 5000.0
+              step: 10.0
+              mode: slider
+mode: restart
+max_exceeded: silent
+triggers:
+  # RODRET (E2201) - TRADFRI (E1743)
+  - trigger: event
+    event_type: zha_event
+    event_data:
+      command: "on"
+      cluster_id: 6
+      endpoint_id: 1
+    id: press-on-zha-e1743-e2201
+  - trigger: mqtt
+    topic: "+/+/action"
+    payload: "on"
+    id: press-on-z2m-e1743-e2201
+  - trigger: event
+    event_type: zha_event
+    event_data:
+      command: "off"
+      cluster_id: 6
+      endpoint_id: 1
+    id: press-off-zha-e1743-e2201
+  - trigger: mqtt
+    topic: "+/+/action"
+    payload: "off"
+    id: press-off-z2m-e1743-e2201
+  - trigger: event
+    event_type: zha_event
+    event_data:
+      command: move_with_on_off
+      cluster_id: 8
+      endpoint_id: 1
+    id: hold-on-zha-e1743-e2201
+  - trigger: mqtt
+    topic: "+/+/action"
+    payload: brightness_move_up
+    id: hold-on-z2m-e1743-e2201
+  - trigger: event
+    event_type: zha_event
+    event_data:
+      command: move
+      cluster_id: 8
+      endpoint_id: 1
+    id: hold-off-zha-e1743-e2201
+  - trigger: mqtt
+    topic: "+/+/action"
+    payload: brightness_move_down
+    id: hold-off-z2m-e1743-e2201
+  - trigger: event
+    event_type: zha_event
+    event_data:
+      command: stop_with_on_off
+      endpoint_id: 1
+      cluster_id: 8
+    id: release-zha-e1743-e2201
+  - trigger: mqtt
+    topic: "+/+/action"
+    payload: brightness_stop
+    id: release-z2m-e1743-e2201
+
+  # SOMRIG - E2213
+  - trigger: event
+    event_type: zha_event
+    event_data:
+      command: short_release
+      endpoint_id: 1
+    id: press-dots1-zha-e2213
+  - trigger: mqtt
+    topic: "+/+/action"
+    payload: 1_short_release
+    id: press-dots1-z2m-e2213
+  - trigger: event
+    event_type: zha_event
+    event_data:
+      command: short_release
+      endpoint_id: 2
+    id: press-dots2-zha-e2213
+  - trigger: mqtt
+    topic: "+/+/action"
+    payload: 2_short_release
+    id: press-dots2-z2m-e2213
+  - trigger: event
+    event_type: zha_event
+    event_data:
+      command: multi_press_complete
+      endpoint_id: 1
+    id: double-press-dots1-zha-e2213
+  - trigger: mqtt
+    topic: "+/+/action"
+    payload: 1_double_press
+    id: double-press-dots1-z2m-e2213
+  - trigger: event
+    event_type: zha_event
+    event_data:
+      command: multi_press_complete
+      endpoint_id: 2
+    id: double-press-dots2-zha-e2213
+  - trigger: mqtt
+    topic: "+/+/action"
+    payload: 2_double_press
+    id: double-press-dots2-z2m-e2213
+  - trigger: event
+    event_type: zha_event
+    event_data:
+      command: long_press
+      endpoint_id: 1
+    id: hold-dots1-zha-e2213
+  - trigger: mqtt
+    topic: "+/+/action"
+    payload: 1_long_press
+    id: hold-dots1-z2m-e2213
+  - trigger: event
+    event_type: zha_event
+    event_data:
+      command: long_press
+      endpoint_id: 2
+    id: hold-dots2-zha-e2213
+  - trigger: mqtt
+    topic: "+/+/action"
+    payload: 2_long_press
+    id: hold-dots2-z2m-e2213
+  - trigger: event
+    event_type: zha_event
+    event_data:
+      command: long_release
+      endpoint_id: 1
+    id: release-hold-dots1-zha-e2213
+  - trigger: mqtt
+    topic: "+/+/action"
+    payload: 1_long_release
+    id: release-hold-dots1-z2m-e2213
+  - trigger: event
+    event_type: zha_event
+    event_data:
+      command: long_release
+      endpoint_id: 2
+    id: release-hold-dots2-zha-e2213
+  - trigger: mqtt
+    topic: "+/+/action"
+    payload: 2_long_release
+    id: release-hold-dots2-z2m-e2213
+variables:
+  helper_force_brightness: !input helper_force_brightness
+  helper_hold_delay: 0.1
+  helper_hold_dim_step: 4
+  helper_min_temperature: !input helper_min_temperature
+  helper_max_temperature: !input helper_max_temperature
+  helper_temperature_change_step: !input helper_temperature_change_step
+  is_mqtt: "{{ trigger.platform == 'mqtt' }}"
+  is_zha: "{{ trigger.platform == 'event' and trigger.event.event_type == 'zha_event' }}"
+  light: !input light
+  mqtt_topic: "{{ trigger.topic }}"
+  remote_devices: !input remote_devices
+  remote_devices_names: "{{ remote_devices | map('device_attr', 'name') | list }}"
+  on_double_press_exposed: !input on_double_press_exposed
+  off_double_press_exposed: !input off_double_press_exposed
+condition:
+  - condition: template
+    value_template: >-
+      {{ 
+        (trigger.event.data.device_id in remote_devices if is_zha) or
+        (trigger.topic.split('/')[1] in remote_devices_names if is_mqtt) 
+      }}
+actions:
+  - choose:
+      - conditions:
+          - condition: trigger
+            id:
+              - press-on-zha-e1743-e2201
+              - press-on-z2m-e1743-e2201
+              - press-dots1-zha-e2213
+              - press-dots1-z2m-e2213
+        sequence:
+          - if:
+              - condition: template
+                value_template: "{{ on_double_press_exposed }}"
+            then:
+              - choose:
+                  - conditions:
+                      - condition: trigger
+                        id:
+                          - press-on-zha-e1743-e2201
+                    sequence:
+                      - wait_for_trigger:
+                          - trigger: event
+                            event_type: zha_event
+                            event_data:
+                              device_id: "{{ remote_device }}"
+                              command: "on"
+                              cluster_id: 6
+                              endpoint_id: 1
+                        timeout:
+                          milliseconds: !input helper_double_press_delay
+                        continue_on_timeout: true
+                      - if:
+                          - condition: template
+                            value_template: "{{ wait.trigger.idx is defined }}"
+                        then: !input on_double_press_action
+                        else:
+                          sequence:
+                            - if:
+                                - condition: state
+                                  entity_id: !input light
+                                  state: "on"
+                              then:
+                                - action: light.turn_on
+                                  data:
+                                    color_temp: "{% if state_attr(light, 'color_temp')|int >= helper_max_temperature %}{{ helper_min_temperature }}{% else %}{{ state_attr(light, 'color_temp')|int + helper_temperature_change_step }}{% endif %}"
+                                    transition: !input helper_temperature_transition_time
+                                  target:
+                                    entity_id: !input light
+                              else:
+                                - choose:
+                                    - conditions: "{{ helper_force_brightness }}"
+                                      sequence:
+                                        - action: light.turn_on
+                                          target:
+                                            entity_id: !input light
+                                          data:
+                                            brightness_pct: !input helper_brightness
+                                  default:
+                                    - action: light.turn_on
+                                      target:
+                                        entity_id: !input light
+                                      data: {}
+                  - conditions:
+                      - condition: trigger
+                        id:
+                          - press-on-z2m-e1743-e2201
+                    sequence:
+                      - wait_for_trigger:
+                          - trigger: mqtt
+                            topic: "{{ mqtt_topic }}"
+                            payload: "on"
+                        timeout:
+                          milliseconds: !input helper_double_press_delay
+                        continue_on_timeout: true
+                      - if:
+                          - condition: template
+                            value_template: "{{ wait.trigger.idx is defined }}"
+                        then: !input on_double_press_action
+                        else:
+                          sequence:
+                            - if:
+                                - condition: state
+                                  entity_id: !input light
+                                  state: "on"
+                              then:
+                                - action: light.turn_on
+                                  data:
+                                    color_temp: "{% if state_attr(light, 'color_temp')|int >= helper_max_temperature %}{{ helper_min_temperature }}{% else %}{{ state_attr(light, 'color_temp')|int + helper_temperature_change_step }}{% endif %}"
+                                    transition: !input helper_temperature_transition_time
+                                  target:
+                                    entity_id: !input light
+                              else:
+                                - choose:
+                                    - conditions: "{{ helper_force_brightness }}"
+                                      sequence:
+                                        - action: light.turn_on
+                                          target:
+                                            entity_id: !input light
+                                          data:
+                                            brightness_pct: !input helper_brightness
+                                  default:
+                                    - action: light.turn_on
+                                      target:
+                                        entity_id: !input light
+                                      data: {}
+                default:
+                  sequence:
+                    - if:
+                        - condition: state
+                          entity_id: !input light
+                          state: "on"
+                      then:
+                        - action: light.turn_on
+                          data:
+                            color_temp: "{% if state_attr(light, 'color_temp')|int >= helper_max_temperature %}{{ helper_min_temperature }}{% else %}{{ state_attr(light, 'color_temp')|int + helper_temperature_change_step }}{% endif %}"
+                            transition: !input helper_temperature_transition_time
+                          target:
+                            entity_id: !input light
+                      else:
+                        - choose:
+                            - conditions: "{{ helper_force_brightness }}"
+                              sequence:
+                                - action: light.turn_on
+                                  target:
+                                    entity_id: !input light
+                                  data:
+                                    brightness_pct: !input helper_brightness
+                          default:
+                            - action: light.turn_on
+                              target:
+                                entity_id: !input light
+                              data: {}
+            else:
+              sequence:
+                - if:
+                    - condition: state
+                      entity_id: !input light
+                      state: "on"
+                  then:
+                    - action: light.turn_on
+                      data:
+                        color_temp: "{% if state_attr(light, 'color_temp')|int >= helper_max_temperature %}{{ helper_min_temperature }}{% else %}{{ state_attr(light, 'color_temp')|int + helper_temperature_change_step }}{% endif %}"
+                        transition: !input helper_temperature_transition_time
+                      target:
+                        entity_id: !input light
+                  else:
+                    - choose:
+                        - conditions: "{{ helper_force_brightness }}"
+                          sequence:
+                            - action: light.turn_on
+                              target:
+                                entity_id: !input light
+                              data:
+                                brightness_pct: !input helper_brightness
+                      default:
+                        - action: light.turn_on
+                          target:
+                            entity_id: !input light
+                          data: {}
+      - conditions:
+          - condition: trigger
+            id:
+              - press-off-zha-e1743-e2201
+              - press-off-z2m-e1743-e2201
+              - press-dots2-zha-e2213
+              - press-dots2-z2m-e2213
+        sequence:
+          - if:
+              - condition: template
+                value_template: "{{ off_double_press_exposed }}"
+            then:
+              - choose:
+                  - conditions:
+                      - condition: trigger
+                        id:
+                          - press-off-zha-e1743-e2201
+                    sequence:
+                      - wait_for_trigger:
+                          - trigger: event
+                            event_type: zha_event
+                            event_data:
+                              device_id: "{{ remote_device }}"
+                              command: "off"
+                              cluster_id: 6
+                              endpoint_id: 1
+                        timeout:
+                          milliseconds: !input helper_double_press_delay
+                        continue_on_timeout: true
+                      - if:
+                          - condition: template
+                            value_template: "{{ wait.trigger.idx is defined }}"
+                        then: !input off_double_press_action
+                        else:
+                          - action: light.turn_off
+                            target:
+                              entity_id: !input light
+                            data: {}
+                  - conditions:
+                      - condition: trigger
+                        id:
+                          - press-off-z2m-e1743-e2201
+                    sequence:
+                      - wait_for_trigger:
+                          - trigger: mqtt
+                            topic: "{{ mqtt_topic }}"
+                            payload: "off"
+                        timeout:
+                          milliseconds: !input helper_double_press_delay
+                        continue_on_timeout: true
+                      - if:
+                          - condition: template
+                            value_template: "{{ wait.trigger.idx is defined }}"
+                        then: !input off_double_press_action
+                        else:
+                          - action: light.turn_off
+                            target:
+                              entity_id: !input light
+                            data: {}
+                default:
+                  - action: light.turn_off
+                    target:
+                      entity_id: !input light
+                    data: {}
+            else:
+              - action: light.turn_off
+                target:
+                  entity_id: !input light
+                data: {}
+      - conditions:
+          - condition: trigger
+            id:
+              - double-press-dots1-zha-e2213
+              - double-press-dots1-z2m-e2213
+        sequence: !input on_double_press_action
+      - conditions:
+          - condition: trigger
+            id:
+              - double-press-dots2-zha-e2213
+              - double-press-dots2-z2m-e2213
+        sequence: !input off_double_press_action
+      - conditions:
+          - condition: trigger
+            id:
+              - hold-on-zha-e1743-e2201
+              - hold-on-z2m-e1743-e2201
+              - hold-dots1-zha-e2213
+              - hold-dots1-z2m-e2213
+        sequence:
+          - repeat:
+              while:
+                - condition: trigger
+                  id:
+                    - hold-on-zha-e1743-e2201
+                    - hold-on-z2m-e1743-e2201
+                    - hold-dots1-zha-e2213
+                    - hold-dots1-z2m-e2213
+              sequence:
+                - parallel:
+                    - action: light.turn_on
+                      target:
+                        entity_id: !input light
+                      data:
+                        brightness_step_pct: "{{ helper_hold_dim_step }}"
+                        transition: "{{ helper_hold_delay }}"
+                    - delay: "{{ helper_hold_delay }}"
+      - conditions:
+          - condition: trigger
+            id:
+              - hold-off-zha-e1743-e2201
+              - hold-off-z2m-e1743-e2201
+              - hold-dots2-zha-e2213
+              - hold-dots2-z2m-e2213
+        sequence:
+          - variables:
+              brightness_pct: "{{ iif(is_state(light, 'on'), state_attr(light, 'brightness'), 0) * 100 / 255 }}"
+              total_iterations_to_zero: "{{ (brightness_pct / helper_hold_dim_step) | round(0, 'ceil') }}"
+          - repeat:
+              count: "{{ total_iterations_to_zero - 1 }}"
+              sequence:
+                - parallel:
+                    - action: light.turn_on
+                      target:
+                        entity_id: !input light
+                      data:
+                        brightness_step_pct: "{{ helper_hold_dim_step | int * -1 }}"
+                        transition: "{{ helper_hold_delay }}"
+                    - delay: "{{ helper_hold_delay }}"
+          - action: light.turn_on
+            target:
+              entity_id: !input light
+            data:
+              brightness_pct: 1
+              transition: "{{ helper_hold_delay }}"

--- a/ikea_E1743-E2201-E2213_ZHA-Z2M_control-light-with-double-press.yaml
+++ b/ikea_E1743-E2201-E2213_ZHA-Z2M_control-light-with-double-press.yaml
@@ -354,6 +354,7 @@ variables:
   remote_devices_names: "{{ remote_devices | map('device_attr', 'name') | list }}"
   on_double_press_exposed: !input on_double_press_exposed
   off_double_press_exposed: !input off_double_press_exposed
+  zha_device_id: "{{ trigger.event.data.device_id if is_zha }}"
 condition:
   - condition: template
     value_template: >-
@@ -385,7 +386,7 @@ actions:
                           - trigger: event
                             event_type: zha_event
                             event_data:
-                              device_id: "{{ remote_device }}"
+                              device_id: "{{ zha_device_id }}"
                               command: "on"
                               cluster_id: 6
                               endpoint_id: 1
@@ -542,7 +543,7 @@ actions:
                           - trigger: event
                             event_type: zha_event
                             event_data:
-                              device_id: "{{ remote_device }}"
+                              device_id: "{{ zha_device_id }}"
                               command: "off"
                               cluster_id: 6
                               endpoint_id: 1

--- a/ikea_E1743-E2201-E2213_ZHA-Z2M_control-light-with-double-press.yaml
+++ b/ikea_E1743-E2201-E2213_ZHA-Z2M_control-light-with-double-press.yaml
@@ -198,7 +198,7 @@ blueprint:
               max: 5000.0
               step: 10.0
               mode: slider
-mode: restart
+mode: single
 max_exceeded: silent
 triggers:
   # RODRET (E2201) - TRADFRI (E1743)

--- a/ikea_E1743-E2201-E2213_ZHA-Z2M_control-light-with-double-press.yaml
+++ b/ikea_E1743-E2201-E2213_ZHA-Z2M_control-light-with-double-press.yaml
@@ -3,7 +3,7 @@ blueprint:
     min_version: 2024.10.0
   author: damru
   domain: automation
-  name: Ikea's Rodret, Somrig or Tradfri 💡 Light control
+  name: Ikea's Rodret, Somrig or Tradfri 💡 Light control with Double Press Actions
   description: >
     ## 💡 Control a light with **IKEA RODRET** or **IKEA SOMRIG** or **IKEA TRADFRI ON/OFF** remotes
 

--- a/ikea_E1743-E2201-E2213_ZHA-Z2M_control-light-with-double-press.yaml
+++ b/ikea_E1743-E2201-E2213_ZHA-Z2M_control-light-with-double-press.yaml
@@ -610,14 +610,11 @@ actions:
               - hold-dots1-zha-e2213
               - hold-dots1-z2m-e2213
         sequence:
+          - variables:
+              brightness_pct: "{{ iif(is_state(light, 'on'), state_attr(light, 'brightness'), 0) * 100 / 255 }}"
+              total_iterations_to_full: "{{ 100 - (brightness_pct / helper_hold_dim_step) | round(0, 'ceil') }}"
           - repeat:
-              while:
-                - condition: trigger
-                  id:
-                    - hold-on-zha-e1743-e2201
-                    - hold-on-z2m-e1743-e2201
-                    - hold-dots1-zha-e2213
-                    - hold-dots1-z2m-e2213
+              count: "{{ total_iterations_to_full - 1 }}"
               sequence:
                 - parallel:
                     - action: light.turn_on
@@ -626,7 +623,52 @@ actions:
                       data:
                         brightness_step_pct: "{{ helper_hold_dim_step }}"
                         transition: "{{ helper_hold_delay }}"
-                    - delay: "{{ helper_hold_delay }}"
+                    - sequence:
+                        - choose:
+                            - conditions:
+                                - condition: trigger
+                                  id:
+                                    - hold-on-zha-e1743-e2201
+                                    - hold-dots1-zha-e2213
+                              sequence:
+                                - wait_for_trigger:
+                                    - trigger: event
+                                      event_type: zha_event
+                                      event_data:
+                                        device_id: "{{ zha_device_id }}"
+                                        command: "stop_with_on_off"
+                                        cluster_id: 8
+                                        endpoint_id: 1
+                                  timeout:
+                                    seconds: "{{ helper_hold_delay }}"
+                                  continue_on_timeout: true
+                                - if:
+                                    - condition: template
+                                      value_template: "{{ wait.trigger.idx is defined }}"
+                                  then:
+                                    - stop: button released
+                            - conditions:
+                                - condition: trigger
+                                  id:
+                                    - hold-on-z2m-e1743-e2201
+                                    - hold-dots1-z2m-e2213
+                              sequence:
+                                - wait_for_trigger:
+                                    - trigger: mqtt
+                                      topic: "{{ mqtt_topic }}"
+                                      payload: "brightness_stop"
+                                    - trigger: mqtt
+                                      topic: "{{ mqtt_topic }}"
+                                      payload: "1_long_release"
+                                  timeout:
+                                    seconds: "{{ helper_hold_delay }}"
+                                  continue_on_timeout: true
+                                - if:
+                                    - condition: template
+                                      value_template: "{{ wait.trigger.idx is defined }}"
+                                  then:
+                                    - stop: button released
+
       - conditions:
           - condition: trigger
             id:
@@ -648,7 +690,51 @@ actions:
                       data:
                         brightness_step_pct: "{{ helper_hold_dim_step | int * -1 }}"
                         transition: "{{ helper_hold_delay }}"
-                    - delay: "{{ helper_hold_delay }}"
+                    - sequence:
+                        - choose:
+                            - conditions:
+                                - condition: trigger
+                                  id:
+                                    - hold-off-zha-e1743-e2201
+                                    - hold-dots2-zha-e2213
+                              sequence:
+                                - wait_for_trigger:
+                                    - trigger: event
+                                      event_type: zha_event
+                                      event_data:
+                                        device_id: "{{ zha_device_id }}"
+                                        command: "stop_with_on_off"
+                                        cluster_id: 8
+                                        endpoint_id: 1
+                                  timeout:
+                                    seconds: "{{ helper_hold_delay }}"
+                                  continue_on_timeout: true
+                                - if:
+                                    - condition: template
+                                      value_template: "{{ wait.trigger.idx is defined }}"
+                                  then:
+                                    - stop: button released
+                            - conditions:
+                                - condition: trigger
+                                  id:
+                                    - hold-off-z2m-e1743-e2201
+                                    - hold-dots2-z2m-e2213
+                              sequence:
+                                - wait_for_trigger:
+                                    - trigger: mqtt
+                                      topic: "{{ mqtt_topic }}"
+                                      payload: "brightness_stop"
+                                    - trigger: mqtt
+                                      topic: "{{ mqtt_topic }}"
+                                      payload: "2_long_release"
+                                  timeout:
+                                    seconds: "{{ helper_hold_delay }}"
+                                  continue_on_timeout: true
+                                - if:
+                                    - condition: template
+                                      value_template: "{{ wait.trigger.idx is defined }}"
+                                  then:
+                                    - stop: button released
           - action: light.turn_on
             target:
               entity_id: !input light

--- a/ikea_E1743-E2201-E2213_ZHA-Z2M_control-light.yaml
+++ b/ikea_E1743-E2201-E2213_ZHA-Z2M_control-light.yaml
@@ -95,6 +95,53 @@ blueprint:
               max: 100.0
               step: 1.0
               mode: slider
+    temperature_section:
+      name: Colour temperature
+      icon: mdi:lightbulb-on-50
+      collapsed: true
+      input:
+        helper_max_temperature:
+          name: Max temperature
+          description: The maximum colour temperature before looping round to the minimum.
+          default: 450
+          selector:
+            number:
+              min: 1.0
+              max: 600.0
+              step: 1.0
+              mode: slider
+        helper_min_temperature:
+          name: Min temperature
+          description: The minimum colour temperature, set when the maximum has been reached and the temperature is changed.
+          default: 225
+          selector:
+            number:
+              min: 1.0
+              max: 600.0
+              step: 1.0
+              mode: slider
+        helper_temperature_change_step:
+          name: Temperature change step
+          description:
+            Step value to add to colour temperature for each change.
+          default: 75
+          selector:
+            number:
+              min: 1.0
+              max: 600.0
+              step: 1.0
+              mode: slider
+        helper_temperature_transition_time:
+          name: Temperature change transition time
+          description:
+            Number of seconds for temperature to transition over.
+          default: 0.5
+          selector:
+            number:
+              min: 0.0
+              max: 10.0
+              step: 0.1
+              mode: slider
 mode: restart
 max_exceeded: silent
 triggers:
@@ -220,6 +267,9 @@ variables:
   helper_force_brightness: !input helper_force_brightness
   helper_hold_delay: 0.1
   helper_hold_dim_step: 4
+  helper_min_temperature: !input helper_min_temperature
+  helper_max_temperature: !input helper_max_temperature
+  helper_temperature_change_step: !input helper_temperature_change_step
   is_mqtt: "{{ trigger.platform == 'mqtt' }}"
   is_zha: "{{ trigger.platform == 'event' and trigger.event.event_type == 'zha_event' }}"
   light: !input light
@@ -243,19 +293,31 @@ actions:
               - press-dots1-zha-e2213
               - press-dots1-z2m-e2213
         sequence:
-          - choose:
-              - conditions: "{{ helper_force_brightness }}"
-                sequence:
+          - if:
+              - condition: state
+                entity_id: !input light
+                state: "on"
+            then:
+              - action: light.turn_on
+                data:
+                  color_temp: "{% if state_attr(light, 'color_temp')|int >= helper_max_temperature %}{{ helper_min_temperature }}{% else %}{{ state_attr(light, 'color_temp')|int + helper_temperature_change_step }}{% endif %}"
+                  transition: !input helper_temperature_transition_time
+                target:
+                  entity_id: !input light
+            else:
+              - choose:
+                  - conditions: "{{ helper_force_brightness }}"
+                    sequence:
+                      - action: light.turn_on
+                        target:
+                          entity_id: !input light
+                        data:
+                          brightness_pct: !input helper_brightness
+                default:
                   - action: light.turn_on
                     target:
                       entity_id: !input light
-                    data:
-                      brightness_pct: !input helper_brightness
-            default:
-              - action: light.turn_on
-                target:
-                  entity_id: !input light
-                data: {}
+                    data: {}
       - conditions:
           - condition: trigger
             id:

--- a/motion-sensing-lights.yaml
+++ b/motion-sensing-lights.yaml
@@ -166,6 +166,15 @@ action:
       platform: state
       entity_id: !input motion_sensors
       to: "off"
+  - if:
+      - condition: state
+        entity_id: !input motion_sensors
+        state: "on"
+    then:
+      - wait_for_trigger:
+        platform: state
+        entity_id: !input motion_sensors
+        to: "off"
   - delay: !input no_motion_wait
   - choose:
       - conditions:

--- a/motion-sensing-lights.yaml
+++ b/motion-sensing-lights.yaml
@@ -169,9 +169,9 @@ action:
         state: "on"
     then:
       - wait_for_trigger:
-        platform: state
-        entity_id: !input motion_sensors
-        to: "off"
+          platform: state
+          entity_id: !input motion_sensors
+          to: "off"
   - delay: !input no_motion_wait
   - choose:
       - conditions:

--- a/motion-sensing-lights.yaml
+++ b/motion-sensing-lights.yaml
@@ -162,13 +162,10 @@ action:
             sequence:
               - service: switch.turn_on
                 target: !input entity_target
-  - wait_for_trigger:
-      platform: state
-      entity_id: !input motion_sensors
-      to: "off"
   - if:
       - condition: state
         entity_id: !input motion_sensors
+        match: any
         state: "on"
     then:
       - wait_for_trigger:

--- a/motion-sensing-lights.yaml
+++ b/motion-sensing-lights.yaml
@@ -1,0 +1,182 @@
+# adapted from https://github.com/iainsmacleod/Home-Assistant-Blueprints
+blueprint:
+  name: Motion- or sensor- activated light with brightness and temperature
+  description: Turn on lights when motion is detected, with brightness and temperature depending on sunrise/sunset (with offsets).
+  domain: automation
+  input:
+    motion_sensors:
+      name: Motion and Occupancy Sensors
+      description: Select one or more motion or occupancy sensors.
+      selector:
+        entity:
+          domain: binary_sensor
+          device_class:
+            - motion
+            - occupancy
+            - door
+          multiple: true
+    entity_target:
+      name: Lights and Switches
+      description: Select one or more lights or switches to control.
+      selector:
+        target:
+          entity:
+            domain:
+              - light
+              - switch
+    no_motion_wait:
+      name: Wait Time
+      description: Time to leave the light on after last motion is detected.
+      default: 120
+      selector:
+        number:
+          min: 0
+          max: 3600
+          unit_of_measurement: seconds
+    use_custom_settings:
+      name: Use Changing Brightness and Temperature
+      description: Enable to use brightness and temperature settings based on surrounding lights and light level.
+      default: true
+      selector:
+        boolean:
+    brightness_bright:
+      name: Brightness (bright setting)
+      description: Set the brightness level (0-255) used when high brightness is set.
+      default: 255
+      selector:
+        number:
+          min: 0
+          max: 255
+    brightness_dim:
+      name: Brightness (dim setting)
+      description: Set the brightness level (0-255) used when low brightness is set.
+      default: 150
+      selector:
+        number:
+          min: 0
+          max: 255
+    sun_offset_brightness:
+      name: Sun Offset for Brightness (Optional)
+      description: Offset from sunrise/sunset in format 'HH:MM' (e.g., '01:00' or '-01:00') at which light brightness reduces.
+      default: "00:00"
+      selector:
+        text:
+    temperature_cool:
+      name: Cool temperature
+      description: A cooler colour temperature, used during the day.
+      default: 250
+      selector:
+        number:
+          min: 1.0
+          max: 600.0
+          step: 1.0
+          mode: slider
+    temperature_warm:
+      name: Warm temperature
+      description: A warmer colour temperature, used at night.
+      default: 375
+      selector:
+        number:
+          min: 1.0
+          max: 600.0
+          step: 1.0
+          mode: slider
+    sun_offset_temperature:
+      name: Sun Offset for Temperature (Optional)
+      description: Offset from sunrise/sunset in format 'HH:MM' (e.g. '01:00' or '-01:00') at which light temperature turns warm.
+      default: "00:00"
+      selector:
+        text:
+
+mode: restart
+max_exceeded: silent
+
+trigger:
+  - platform: state
+    entity_id: !input motion_sensors
+    to: "on"
+
+variables:
+  use_custom_settings: !input use_custom_settings
+  entity_target: !input entity_target
+
+action:
+  - choose:
+      - conditions:
+          - condition: template
+            value_template: "{{ use_custom_settings }}"
+        sequence:
+          - choose:
+              - conditions:
+                  - condition: template
+                    value_template: "{{ 'light.' in entity_target.entity_id|string }}"
+                sequence:
+
+                  - if:
+                      - condition: sun
+                        after: sunrise
+                        after_offset: !input sun_offset_brightness
+                        before: sunset
+                        before_offset: !input sun_offset_brightness
+                    then:
+                      - variables:
+                          brightness: !input brightness_bright
+                    else:
+                      - variables:
+                          brightness: !input brightness_dim
+                  - if:
+                      - condition: sun
+                        after: sunrise
+                        after_offset: !input sun_offset_temperature
+                        before: sunset
+                        before_offset: !input sun_offset_temperature
+                    then:
+                      - variables:
+                          temperature: !input temperature_cool
+                    else:
+                      - variables:
+                          temperature: !input temperature_warm
+
+                  - service: light.turn_on
+                    target: !input entity_target
+                    data:
+                      brightness: "{{ brightness }}"
+                      color_temp: "{{ temperature }}"
+              - conditions:
+                  - condition: template
+                    value_template: "{{ 'switch.' in entity_target.entity_id|string }}"
+                sequence:
+                  - service: switch.turn_on
+                    target: !input entity_target
+    default:
+      - choose:
+          - conditions:
+              - condition: template
+                value_template: "{{ 'light.' in entity_target.entity_id|string }}"
+            sequence:
+              - service: light.turn_on
+                target: !input entity_target
+          - conditions:
+              - condition: template
+                value_template: "{{ 'switch.' in entity_target.entity_id|string }}"
+            sequence:
+              - service: switch.turn_on
+                target: !input entity_target
+  - wait_for_trigger:
+      platform: state
+      entity_id: !input motion_sensors
+      to: "off"
+  - delay: !input no_motion_wait
+  - choose:
+      - conditions:
+          - condition: template
+            value_template: "{{ 'light.' in entity_target.entity_id|string }}"
+        sequence:
+          - service: light.turn_off
+            target: !input entity_target
+      - conditions:
+          - condition: template
+            value_template: "{{ 'switch.' in entity_target.entity_id|string }}"
+        sequence:
+          - service: switch.turn_off
+            target: !input entity_target

--- a/philips-hue-dimmer-v2_RWL022_control-light.yaml
+++ b/philips-hue-dimmer-v2_RWL022_control-light.yaml
@@ -1,0 +1,321 @@
+blueprint:
+  name: ZHA - Philips Hue Dimmer Switch v2 - Light Control
+  description: |
+    Control lights with a Philips Hue Dimmer Switch v2.
+
+    The top "power" button behaviour is adjustable. By default it toggles the light with the last set brightness.
+    
+    Dim up/down buttons will change the brightness smoothly and can be pressed
+    and held until the brightness is satisfactory.
+
+    The bottom "scene" button will change the light temperature.
+    
+    The "power" and "scene" buttons can be assigned to an action when double
+    or triple pressed. This allows you to assign e.g. a scene or something else.
+
+    The minimum brightness setting will limit how low you can set the brightness. This will 
+    prevent dimming down until the light turns off. Set this to zero to disable this feature.
+
+    Does this blueprint not work for you? Did you add your Hue dimmer to ZHA before July 2020?
+    It might help to press the 'Reconfigure device' button on the ZHA Device info page.
+    The naming of the command attribute in the zha_event was changed back then. 
+
+  domain: automation
+
+  # Define the inputs for the blueprint
+  input:
+    remote:
+      name: Philips Hue Dimmer Switch v2
+      description: Pick RWL022 (v2 dimmer)
+      selector:
+        device:
+          integration: zha
+          manufacturer: Signify Netherlands B.V.
+          entity:
+            domain: sensor
+            device_class: battery
+    light:
+      name: The light(s) to control
+      description: >
+        The light entity to control
+        (only a single entity is supported; use light groups when needed)
+      selector:
+        entity:
+          domain: light
+    power_button_mode:
+      name: The mode for the "power" button
+      description: >
+        Choose behaviour when pressing the "power" button.
+          - Fixed brightness; Always turn on the lights with a fixed brightness
+          - Fixed brightness when on; If light is off, turn on the light; If light is on, set it to a fixed brightness
+          - Always toggle; Always turn on the light to the last set brightness
+          - Always toggle fixed brightness; Always turn on the light with a fixed brightness
+      default: always toggle
+      selector:
+        select:
+          options:
+            - fixed brightness
+            - fixed brightness when on
+            - always toggle
+            - always toggle fixed brightness
+    fixed_brightness:
+      name: Fixed Brightness
+      description: The fixed brightness of the light(s) when turning on
+      default: 255
+      selector:
+        number:
+          min: 0.0
+          max: 255.0
+          mode: slider
+          step: 1.0
+    min_brightness:
+      name: Minimum Brightness
+      description: >
+        The minimum brightness of the light(s) when dimming down.
+        Set this to zero to disable this feature.
+      default: 1
+      selector:
+        number:
+          min: 0.0
+          max: 255.0
+          mode: slider
+          step: 1.0
+    power_button_section:
+      name: Power button
+      icon: mdi:power
+      collapsed: false
+      input:
+        button_power_double:
+          name: Power button - Double press
+          description: Action to run when double pressing the power button
+          default: []
+          selector:
+            action:
+        button_power_triple:
+          name: Power button - Triple press
+          description: Action to run when triple pressing the power button
+          default: []
+          selector:
+            action:
+        button_power_long:
+          name: Power button - Long press (repeating)
+          description: Action to run when holding down the power button
+          default: []
+          selector:
+            action:
+    scene_button_section:
+      name: Scene button
+      icon: mdi:palette
+      collapsed: false
+      input:
+        button_scene_double:
+          name: Scene button - Double press
+          description: Action to run when double pressing the scene button
+          default: []
+          selector:
+            action:
+        button_scene_triple:
+          name: Scene button - Triple press
+          description: Action to run when triple pressing the scene button
+          default: []
+          selector:
+            action:
+        button_scene_long:
+          name: Scene button - Long press (repeating)
+          description: Action to run when holding down the scene button
+          default: []
+          selector:
+            action:
+    temperature_section:
+      name: Colour temperature
+      icon: mdi:lightbulb-on-50
+      collapsed: true
+      input:
+        max_temperature:
+          name: Max temperature
+          description: The maximum colour temperature before looping round to the minimum.
+          default: 375
+          selector:
+            number:
+              min: 1.0
+              max: 600.0
+              step: 1.0
+              mode: slider
+        min_temperature:
+          name: Min temperature
+          description: The minimum colour temperature, set when the maximum has been reached and the temperature is changed.
+          default: 225
+          selector:
+            number:
+              min: 1.0
+              max: 600.0
+              step: 1.0
+              mode: slider
+        temperature_change_step:
+          name: Temperature change step
+          description:
+            Step value to add to colour temperature for each change.
+          default: 50
+          selector:
+            number:
+              min: 1.0
+              max: 600.0
+              step: 1.0
+              mode: slider
+        temperature_transition_time:
+          name: Temperature change transition time
+          description:
+            Number of seconds for temperature to transition over.
+          default: 0.5
+          selector:
+            number:
+              min: 0.0
+              max: 10.0
+              step: 0.1
+              mode: slider
+
+# mode: restart
+max_exceeded: silent
+
+variables:
+  light                   : !input light
+  power_button_mode       : !input power_button_mode
+  fixed_brightness        : !input fixed_brightness
+  min_brightness          : !input min_brightness
+  min_temperature         : !input min_temperature
+  max_temperature         : !input max_temperature
+  temperature_change_step : !input temperature_change_step
+
+# Trigger the automation when the selected dimmer remote sends an event
+# Also only trigger on cluster_id 64512. This ignores the 'old' events with cluster_id 8.
+trigger:
+- platform: event
+  event_type: zha_event
+  event_data:
+    device_id: !input 'remote'
+    cluster_id: 64512
+
+action:
+  - variables:
+      command        : '{{ trigger.event.data.command }}'
+      cur_brightness : '{{ state_attr(light, "brightness") | default(0) }}'
+      is_turned_on   : '{{ states(light) == "on" }}'
+  
+  - choose:
+    - conditions: '{{ command == "on_press" }}'
+      sequence:
+      - choose:
+        - conditions: '{{ power_button_mode == "fixed brightness" }}'
+          sequence:
+          - action: light.turn_on
+            data:
+              entity_id : !input 'light'
+              transition: 0.5
+              brightness: !input 'fixed_brightness'
+        - conditions:
+            - '{{ power_button_mode == "fixed brightness when on" }}'
+            - '{{ is_turned_on }}'
+          sequence:
+          - action: light.turn_on
+            data:
+              entity_id : !input 'light'
+              transition: 0.5
+              brightness: !input 'fixed_brightness'
+        - conditions:
+            - '{{ power_button_mode == "always toggle fixed brightness" }}'
+            - '{{ is_turned_on }}'
+          sequence:
+          - action: light.turn_off
+            data:
+              entity_id : !input 'light'
+              transition: 0.5
+        - conditions:
+            - '{{ power_button_mode == "always toggle fixed brightness" }}'
+          sequence:
+          - action: light.turn_on
+            data:
+              entity_id : !input 'light'
+              transition: 0.5
+              brightness: !input 'fixed_brightness'
+        default:
+        - action: light.toggle
+          data:
+            entity_id : !input 'light'
+            transition: 0.5
+
+    - conditions: '{{ command == "on_double_press" }}'
+      sequence: !input button_power_double
+
+    - conditions: '{{ command == "on_triple_press" }}'
+      sequence: !input button_power_triple
+
+    - conditions: '{{ command == "on_hold" }}'
+      sequence: !input button_power_long
+
+    - conditions: '{{ command == "off_press" }}'
+      sequence:
+      - action: light.turn_on
+        data:
+          color_temp: "{% if state_attr(light, 'color_temp')|int >= max_temperature %}{{ min_temperature }}{% else %}{{ state_attr(light, 'color_temp')|int + temperature_change_step }}{% endif %}"
+          transition: !input temperature_transition_time
+        target:
+          entity_id: !input light
+
+    - conditions: '{{ command == "off_double_press" }}'
+      sequence: !input button_scene_double
+
+    - conditions: '{{ command == "off_triple_press" }}'
+      sequence: !input button_scene_triple
+
+    - conditions: '{{ command == "off_hold" }}'
+      sequence: !input button_scene_long
+
+    - conditions: '{{ command == "up_press" }}'
+      sequence:
+      - action: light.turn_on
+        data:
+          entity_id : !input 'light'
+          brightness_step: 25
+          transition: 0.5
+  
+    - conditions: '{{ command == "up_hold" }}'
+      sequence:
+      - action: light.turn_on
+        data:
+          entity_id : !input 'light'
+          brightness_step: 50
+          transition: 1
+  
+    - conditions: '{{ command == "down_press" }}'
+      sequence:
+      - choose:
+        - conditions: '{{ (cur_brightness - 25) >= min_brightness }}'
+          sequence:
+          - action: light.turn_on
+            data:
+              entity_id : !input 'light'
+              transition: 0.5
+              brightness_step: -25
+        default:
+        - action: light.turn_on
+          data:
+            entity_id : !input 'light'
+            transition: 0.5
+            brightness: !input 'min_brightness'
+  
+    - conditions: '{{ command == "down_hold" }}'
+      sequence:
+      - choose:
+        - conditions: '{{ (cur_brightness - 50) >= min_brightness }}'
+          sequence:
+          - action: light.turn_on
+            data:
+              entity_id : !input 'light'
+              transition: 1
+              brightness_step: -50
+        default:
+        - action: light.turn_on
+          data:
+            entity_id : !input 'light'
+            transition: 1
+            brightness: !input 'min_brightness'


### PR DESCRIPTION
Hi! Not sure if this is a feature others would find useful, so feel free to close it if not, but I like being able to adjust temperature from the dimmer. I've found the easiest way to do this is just to press the on button (when the light is already on, of course) - similar to how the v1 Philips Hue dimmers (below) work.

This PR changes the default functionality of the on button in the light-only blueprint to increment colour temperature when the light is turned on, instead of forcing the brightness level (if enabled, otherwise doing nothing). There are helper options for configuring max/min temperatures and the step to increment by. The change is handled by adding the step amount to the current temperature, unless the current temperature is greater than or equal to the maximum. Transition time can also be adjusted with a helper option.

This does however require that the light entity supports the `color_temp` attribute.

Thanks for your work on this blueprint - it's really useful!

![Philips Hue dimmer switch v1](https://www.techthatworks.net/wp-content/uploads/2021/10/Hue_Dimmer_Switch_1.jpg "Philips Hue dimmer switch v1")