### PR TITLE
fix: remove dependency on zha device id when using z2m

### DIFF
--- a/ikea_E1743-E2201-E2213_ZHA-Z2M_control-anything.yaml
+++ b/ikea_E1743-E2201-E2213_ZHA-Z2M_control-anything.yaml
@@ -314,7 +314,7 @@ variables:
   off_double_press_exposed: !input off_double_press_exposed
   remote_devices: !input remote_devices
   remote_devices_names: "{{ remote_devices | map('device_attr', 'name') | list }}"
-  zha_device_id: "{{ trigger.event.data.device_id }}"
+  zha_device_id: "{{ trigger.event.data.device_id if is_zha }}"
 condition:
   - condition: template
     value_template: >-


### PR DESCRIPTION
The latest change (#27) introduced a dependency on device id for z2m users, resulting in breaking errors: 

> ERROR (MainThread) [homeassistant.helpers.template] Template variable error: 'dict object' has no attribute 'event' when rendering '{{ trigger.event.data.device_id }}'
> ERROR (MainThread) [homeassistant.components.automation.test] Error rendering variables: UndefinedError: 'dict object' has no attribute 'event'

This small fix removes the dependency.

Thanks for creating this blueprint!