### PR TITLE
chore: Add filter for RODRET wireless dimmer with different model name

### DIFF
--- a/ikea_E1743-E2201-E2213_ZHA-Z2M_control-anything.yaml
+++ b/ikea_E1743-E2201-E2213_ZHA-Z2M_control-anything.yaml
@@ -38,6 +38,9 @@ blueprint:
               model: RODRET Dimmer
             - integration: zha
               manufacturer: IKEA of Sweden
+              model: RODRET wireless dimmer
+            - integration: zha
+              manufacturer: IKEA of Sweden
               model: SOMRIG shortcut button
             - integration: mqtt
               manufacturer: IKEA


### PR DESCRIPTION
I just got one of the RODRET switches today but it wasn't coming up in this filter because it had a slightly different model name. I left the existing one that was in there just in case it was something that had changed.

Great blueprint by the way, after this change I was able to setup my remote very easily.