### PR TITLE
feat: refactor triggers

### DIFF
--- a/ikea_simple-remotes_control-anything.yaml
+++ b/ikea_simple-remotes_control-anything.yaml
@@ -175,6 +175,12 @@ blueprint:
               mode: slider
 mode: single
 max_exceeded: silent
+
+trigger_variables:
+  mqtt_enabled: "{{ integration_entities('mqtt') != [] }}"
+  remote_devices: !input remote_devices
+  zha_enabled: "{{ integration_entities('zha') != [] }}"
+
 triggers:
   ###########################
   # SINGLE PRESSES
@@ -186,10 +192,12 @@ triggers:
       cluster_id: 6
       endpoint_id: 1
     id: press-on-zha
+    enabled: "{{ zha_enabled }}"
   - trigger: mqtt
     topic: "+/+/action"
     payload: "on"
     id: press-on-z2m
+    enabled: "{{ mqtt_enabled }}"
   - trigger: event
     event_type: zha_event
     event_data:
@@ -197,30 +205,36 @@ triggers:
       cluster_id: 6
       endpoint_id: 1
     id: press-off-zha
+    enabled: "{{ zha_enabled }}"
   - trigger: mqtt
     topic: "+/+/action"
     payload: "off"
     id: press-off-z2m
+    enabled: "{{ mqtt_enabled }}"
   - trigger: event
     event_type: zha_event
     event_data:
       command: short_release
       endpoint_id: 1
     id: press-on-zha-somrig
+    enabled: "{{ zha_enabled }}"
   - trigger: mqtt
     topic: "+/+/action"
     payload: 1_short_release
     id: press-on-z2m-somrig
+    enabled: "{{ mqtt_enabled }}"
   - trigger: event
     event_type: zha_event
     event_data:
       command: short_release
       endpoint_id: 2
     id: press-off-zha-somrig
+    enabled: "{{ zha_enabled }}"
   - trigger: mqtt
     topic: "+/+/action"
     payload: 2_short_release
     id: press-off-z2m-somrig
+    enabled: "{{ mqtt_enabled }}"
 
     ###########################
     # DOUBLE PRESSES
@@ -229,30 +243,36 @@ triggers:
     topic: "+/+/action"
     payload: "on_double"
     id: double-press-on-z2m-bilresa
+    enabled: "{{ mqtt_enabled }}"
   - trigger: mqtt
     topic: "+/+/action"
     payload: "off_double"
     id: double-press-off-z2m-bilresa
+    enabled: "{{ mqtt_enabled }}"
   - trigger: event
     event_type: zha_event
     event_data:
       command: multi_press_complete
       endpoint_id: 1
     id: double-press-on-zha-somrig
+    enabled: "{{ zha_enabled }}"
   - trigger: mqtt
     topic: "+/+/action"
     payload: 1_double_press
     id: double-press-on-z2m-somrig
+    enabled: "{{ mqtt_enabled }}"
   - trigger: event
     event_type: zha_event
     event_data:
       command: multi_press_complete
       endpoint_id: 2
     id: double-press-off-zha-somrig
+    enabled: "{{ zha_enabled }}"
   - trigger: mqtt
     topic: "+/+/action"
     payload: 2_double_press
     id: double-press-off-z2m-somrig
+    enabled: "{{ mqtt_enabled }}"
 
   ###########################
   # LONG PRESSES
@@ -264,10 +284,12 @@ triggers:
       cluster_id: 8
       endpoint_id: 1
     id: hold-on-zha
+    enabled: "{{ zha_enabled }}"
   - trigger: mqtt
     topic: "+/+/action"
     payload: brightness_move_up
     id: hold-on-z2m
+    enabled: "{{ mqtt_enabled }}"
   - trigger: event
     event_type: zha_event
     event_data:
@@ -275,10 +297,12 @@ triggers:
       cluster_id: 8
       endpoint_id: 1
     id: hold-off-zha
+    enabled: "{{ zha_enabled }}"
   - trigger: mqtt
     topic: "+/+/action"
     payload: brightness_move_down
     id: hold-off-z2m
+    enabled: "{{ mqtt_enabled }}"
   - trigger: event
     event_type: zha_event
     event_data:
@@ -286,50 +310,60 @@ triggers:
       cluster_id: 8
       command: stop_with_on_off
     id: release-zha
+    enabled: "{{ zha_enabled }}"
   - trigger: mqtt
     topic: "+/+/action"
     payload: brightness_stop
     id: release-z2m
+    enabled: "{{ mqtt_enabled }}"
   - trigger: event
     event_type: zha_event
     event_data:
       command: long_press
       endpoint_id: 1
     id: hold-on-zha-somrig
+    enabled: "{{ zha_enabled }}"
   - trigger: mqtt
     topic: "+/+/action"
     payload: 1_long_press
     id: hold-on-z2m-somrig
+    enabled: "{{ mqtt_enabled }}"
   - trigger: event
     event_type: zha_event
     event_data:
       command: long_press
       endpoint_id: 2
     id: hold-off-zha-somrig
+    enabled: "{{ zha_enabled }}"
   - trigger: mqtt
     topic: "+/+/action"
     payload: 2_long_press
     id: hold-off-z2m-somrig
+    enabled: "{{ mqtt_enabled }}"
   - trigger: event
     event_type: zha_event
     event_data:
       command: long_release
       endpoint_id: 1
     id: release-hold-on-zha-somrig
+    enabled: "{{ zha_enabled }}"
   - trigger: mqtt
     topic: "+/+/action"
     payload: 1_long_release
     id: release-hold-on-z2m-somrig
+    enabled: "{{ mqtt_enabled }}"
   - trigger: event
     event_type: zha_event
     event_data:
       command: long_release
       endpoint_id: 2
     id: release-hold-off-zha-somrig
+    enabled: "{{ zha_enabled }}"
   - trigger: mqtt
     topic: "+/+/action"
     payload: 2_long_release
     id: release-hold-off-z2m-somrig
+    enabled: "{{ mqtt_enabled }}"
 variables:
   is_mqtt: "{{ trigger.platform == 'mqtt' }}"
   is_zha: "{{ trigger.platform == 'event' and trigger.event.event_type == 'zha_event' }}"
@@ -360,46 +394,27 @@ actions:
               - condition: template
                 value_template: "{{ on_double_press_exposed }}"
             then:
-              - choose:
-                  - conditions:
-                      - condition: trigger
-                        id:
-                          - press-on-zha
-                    sequence:
-                      - wait_for_trigger:
-                          - trigger: event
-                            event_type: zha_event
-                            event_data:
-                              device_id: "{{ zha_device_id }}"
-                              command: "on"
-                              cluster_id: 6
-                              endpoint_id: 1
-                        timeout:
-                          milliseconds: !input helper_double_press_delay
-                        continue_on_timeout: true
-                      - if:
-                          - condition: template
-                            value_template: "{{ wait.trigger.idx is defined }}"
-                        then: !input on_double_press_action
-                        else: !input on_press_action
-                  - conditions:
-                      - condition: trigger
-                        id:
-                          - press-on-z2m
-                    sequence:
-                      - wait_for_trigger:
-                          - trigger: mqtt
-                            topic: "{{ mqtt_topic }}"
-                            payload: "on"
-                        timeout:
-                          milliseconds: !input helper_double_press_delay
-                        continue_on_timeout: true
-                      - if:
-                          - condition: template
-                            value_template: "{{ wait.trigger.idx is defined }}"
-                        then: !input on_double_press_action
-                        else: !input on_press_action
-                default: !input on_press_action
+              - wait_for_trigger:
+                  - trigger: event
+                    event_type: zha_event
+                    event_data:
+                      device_id: "{{ zha_device_id }}"
+                      command: "on"
+                      cluster_id: 6
+                      endpoint_id: 1
+                    enabled: "{{ is_zha }}"
+                  - trigger: mqtt
+                    topic: "{{ mqtt_topic }}"
+                    payload: "on"
+                    enabled: "{{ is_mqtt }}"
+                timeout:
+                  milliseconds: !input helper_double_press_delay
+                continue_on_timeout: true
+              - if:
+                  - condition: template
+                    value_template: "{{ wait.trigger.idx is defined }}"
+                then: !input on_double_press_action
+                else: !input on_press_action
             else: !input on_press_action
       - conditions:
           - condition: trigger
@@ -413,46 +428,27 @@ actions:
               - condition: template
                 value_template: "{{ off_double_press_exposed }}"
             then:
-              - choose:
-                  - conditions:
-                      - condition: trigger
-                        id:
-                          - press-off-zha
-                    sequence:
-                      - wait_for_trigger:
-                          - trigger: event
-                            event_type: zha_event
-                            event_data:
-                              device_id: "{{ zha_device_id }}"
-                              command: "off"
-                              cluster_id: 6
-                              endpoint_id: 1
-                        timeout:
-                          milliseconds: !input helper_double_press_delay
-                        continue_on_timeout: true
-                      - if:
-                          - condition: template
-                            value_template: "{{ wait.trigger.idx is defined }}"
-                        then: !input off_double_press_action
-                        else: !input off_press_action
-                  - conditions:
-                      - condition: trigger
-                        id:
-                          - press-off-z2m
-                    sequence:
-                      - wait_for_trigger:
-                          - trigger: mqtt
-                            topic: "{{ mqtt_topic }}"
-                            payload: "off"
-                        timeout:
-                          milliseconds: !input helper_double_press_delay
-                        continue_on_timeout: true
-                      - if:
-                          - condition: template
-                            value_template: "{{ wait.trigger.idx is defined }}"
-                        then: !input off_double_press_action
-                        else: !input off_press_action
-                default: !input off_press_action
+              - wait_for_trigger:
+                  - trigger: event
+                    event_type: zha_event
+                    event_data:
+                      device_id: "{{ zha_device_id }}"
+                      command: "off"
+                      cluster_id: 6
+                      endpoint_id: 1
+                    enabled: "{{ is_zha }}"
+                  - trigger: mqtt
+                    topic: "{{ mqtt_topic }}"
+                    payload: "off"
+                    enabled: "{{ is_mqtt }}"
+                timeout:
+                  milliseconds: !input helper_double_press_delay
+                continue_on_timeout: true
+              - if:
+                  - condition: template
+                    value_template: "{{ wait.trigger.idx is defined }}"
+                then: !input off_double_press_action
+                else: !input off_press_action
             else: !input off_press_action
       - conditions:
           - condition: trigger
@@ -484,50 +480,31 @@ actions:
                 - parallel:
                     - sequence: !input on_hold_action
                     - sequence:
-                        - choose:
-                            - conditions:
-                                - condition: trigger
-                                  id:
-                                    - hold-on-zha
-                                    - hold-on-zha-somrig
-                              sequence:
-                                - wait_for_trigger:
-                                    - trigger: event
-                                      event_type: zha_event
-                                      event_data:
-                                        device_id: "{{ zha_device_id }}"
-                                        command: "stop_with_on_off"
-                                        cluster_id: 8
-                                        endpoint_id: 1
-                                  timeout:
-                                    milliseconds: !input helper_hold_delay
-                                  continue_on_timeout: true
-                                - if:
-                                    - condition: template
-                                      value_template: "{{ wait.trigger.idx is defined }}"
-                                  then:
-                                    - stop: button released
-                            - conditions:
-                                - condition: trigger
-                                  id:
-                                    - hold-on-z2m
-                                    - hold-on-z2m-somrig
-                              sequence:
-                                - wait_for_trigger:
-                                    - trigger: mqtt
-                                      topic: "{{ mqtt_topic }}"
-                                      payload: "brightness_stop"
-                                    - trigger: mqtt
-                                      topic: "{{ mqtt_topic }}"
-                                      payload: "1_long_release"
-                                  timeout:
-                                    milliseconds: !input helper_hold_delay
-                                  continue_on_timeout: true
-                                - if:
-                                    - condition: template
-                                      value_template: "{{ wait.trigger.idx is defined }}"
-                                  then:
-                                    - stop: button released
+                        - wait_for_trigger:
+                            - trigger: event
+                              event_type: zha_event
+                              event_data:
+                                device_id: "{{ zha_device_id }}"
+                                command: "stop_with_on_off"
+                                cluster_id: 8
+                                endpoint_id: 1
+                              enabled: "{{ is_zha }}"
+                            - trigger: mqtt
+                              topic: "{{ mqtt_topic }}"
+                              payload: "brightness_stop"
+                              enabled: "{{ is_mqtt }}"
+                            - trigger: mqtt
+                              topic: "{{ mqtt_topic }}"
+                              payload: "1_long_release"
+                              enabled: "{{ is_mqtt }}"
+                          timeout:
+                            milliseconds: !input helper_hold_delay
+                          continue_on_timeout: true
+                        - if:
+                            - condition: template
+                              value_template: "{{ wait.trigger.idx is defined }}"
+                          then:
+                            - stop: button released
       - conditions:
           - condition: trigger
             id:
@@ -542,47 +519,28 @@ actions:
                 - parallel:
                     - sequence: !input off_hold_action
                     - sequence:
-                        - choose:
-                            - conditions:
-                                - condition: trigger
-                                  id:
-                                    - hold-off-zha
-                                    - hold-off-zha-somrig
-                              sequence:
-                                - wait_for_trigger:
-                                    - trigger: event
-                                      event_type: zha_event
-                                      event_data:
-                                        device_id: "{{ zha_device_id }}"
-                                        command: "stop_with_on_off"
-                                        cluster_id: 8
-                                        endpoint_id: 1
-                                  timeout:
-                                    milliseconds: !input helper_hold_delay
-                                  continue_on_timeout: true
-                                - if:
-                                    - condition: template
-                                      value_template: "{{ wait.trigger.idx is defined }}"
-                                  then:
-                                    - stop: button released
-                            - conditions:
-                                - condition: trigger
-                                  id:
-                                    - hold-off-z2m
-                                    - hold-off-z2m-somrig
-                              sequence:
-                                - wait_for_trigger:
-                                    - trigger: mqtt
-                                      topic: "{{ mqtt_topic }}"
-                                      payload: "brightness_stop"
-                                    - trigger: mqtt
-                                      topic: "{{ mqtt_topic }}"
-                                      payload: "2_long_release"
-                                  timeout:
-                                    milliseconds: !input helper_hold_delay
-                                  continue_on_timeout: true
-                                - if:
-                                    - condition: template
-                                      value_template: "{{ wait.trigger.idx is defined }}"
-                                  then:
-                                    - stop: button released
+                        - wait_for_trigger:
+                            - trigger: event
+                              event_type: zha_event
+                              event_data:
+                                device_id: "{{ zha_device_id }}"
+                                command: "stop_with_on_off"
+                                cluster_id: 8
+                                endpoint_id: 1
+                              enabled: "{{ is_zha }}"
+                            - trigger: mqtt
+                              topic: "{{ mqtt_topic }}"
+                              payload: "brightness_stop"
+                              enabled: "{{ is_mqtt }}"
+                            - trigger: mqtt
+                              topic: "{{ mqtt_topic }}"
+                              payload: "2_long_release"
+                              enabled: "{{ is_mqtt }}"
+                          timeout:
+                            milliseconds: !input helper_hold_delay
+                          continue_on_timeout: true
+                        - if:
+                            - condition: template
+                              value_template: "{{ wait.trigger.idx is defined }}"
+                          then:
+                            - stop: button released

--- a/ikea_simple-remotes_control-light.yaml
+++ b/ikea_simple-remotes_control-light.yaml
@@ -106,6 +106,12 @@ blueprint:
               mode: slider
 mode: restart
 max_exceeded: silent
+
+trigger_variables:
+  mqtt_enabled: "{{ integration_entities('mqtt') != [] }}"
+  remote_devices: !input remote_devices
+  zha_enabled: "{{ integration_entities('zha') != [] }}"
+
 triggers:
   ###########################
   # SINGLE PRESSES
@@ -117,10 +123,12 @@ triggers:
       cluster_id: 6
       endpoint_id: 1
     id: press-on-zha
+    enabled: "{{ zha_enabled }}"
   - trigger: mqtt
     topic: "+/+/action"
     payload: "on"
     id: press-on-z2m
+    enabled: "{{ mqtt_enabled }}"
   - trigger: event
     event_type: zha_event
     event_data:
@@ -128,30 +136,36 @@ triggers:
       cluster_id: 6
       endpoint_id: 1
     id: press-off-zha
+    enabled: "{{ zha_enabled }}"
   - trigger: mqtt
     topic: "+/+/action"
     payload: "off"
     id: press-off-z2m
+    enabled: "{{ mqtt_enabled }}"
   - trigger: event
     event_type: zha_event
     event_data:
       command: short_release
       endpoint_id: 1
     id: press-on-zha-somrig
+    enabled: "{{ zha_enabled }}"
   - trigger: mqtt
     topic: "+/+/action"
     payload: 1_short_release
     id: press-on-z2m-somrig
+    enabled: "{{ mqtt_enabled }}"
   - trigger: event
     event_type: zha_event
     event_data:
       command: short_release
       endpoint_id: 2
     id: press-off-zha-somrig
+    enabled: "{{ zha_enabled }}"
   - trigger: mqtt
     topic: "+/+/action"
     payload: 2_short_release
     id: press-off-z2m-somrig
+    enabled: "{{ mqtt_enabled }}"
 
   ###########################
   # LONG PRESSES
@@ -163,10 +177,12 @@ triggers:
       cluster_id: 8
       endpoint_id: 1
     id: hold-on-zha
+    enabled: "{{ zha_enabled }}"
   - trigger: mqtt
     topic: "+/+/action"
     payload: brightness_move_up
     id: hold-on-z2m
+    enabled: "{{ mqtt_enabled }}"
   - trigger: event
     event_type: zha_event
     event_data:
@@ -174,10 +190,12 @@ triggers:
       cluster_id: 8
       endpoint_id: 1
     id: hold-off-zha
+    enabled: "{{ zha_enabled }}"
   - trigger: mqtt
     topic: "+/+/action"
     payload: brightness_move_down
     id: hold-off-z2m
+    enabled: "{{ mqtt_enabled }}"
   - trigger: event
     event_type: zha_event
     event_data:
@@ -185,50 +203,60 @@ triggers:
       endpoint_id: 1
       cluster_id: 8
     id: release-zha
+    enabled: "{{ zha_enabled }}"
   - trigger: mqtt
     topic: "+/+/action"
     payload: brightness_stop
     id: release-z2m
+    enabled: "{{ mqtt_enabled }}"
   - trigger: event
     event_type: zha_event
     event_data:
       command: long_press
       endpoint_id: 1
     id: hold-on-zha-somrig
+    enabled: "{{ zha_enabled }}"
   - trigger: mqtt
     topic: "+/+/action"
     payload: 1_long_press
     id: hold-on-z2m-somrig
+    enabled: "{{ mqtt_enabled }}"
   - trigger: event
     event_type: zha_event
     event_data:
       command: long_press
       endpoint_id: 2
     id: hold-off-zha-somrig
+    enabled: "{{ zha_enabled }}"
   - trigger: mqtt
     topic: "+/+/action"
     payload: 2_long_press
     id: hold-off-z2m-somrig
+    enabled: "{{ mqtt_enabled }}"
   - trigger: event
     event_type: zha_event
     event_data:
       command: long_release
       endpoint_id: 1
     id: release-hold-on-zha-somrig
+    enabled: "{{ zha_enabled }}"
   - trigger: mqtt
     topic: "+/+/action"
     payload: 1_long_release
     id: release-hold-on-z2m-somrig
+    enabled: "{{ mqtt_enabled }}"
   - trigger: event
     event_type: zha_event
     event_data:
       command: long_release
       endpoint_id: 2
     id: release-hold-off-zha-somrig
+    enabled: "{{ zha_enabled }}"
   - trigger: mqtt
     topic: "+/+/action"
     payload: 2_long_release
     id: release-hold-off-z2m-somrig
+    enabled: "{{ mqtt_enabled }}"
 variables:
   helper_force_brightness: !input helper_force_brightness
   helper_hold_delay: 0.1


### PR DESCRIPTION
🥇  Kudos to @JonMerlevede in https://github.com/damru/ha-blueprints/pull/33 for this.


This pull request updates the `ikea_simple-remotes_control-anything.yaml` and `ikea_simple-remotes_control-light.yaml` blueprints to improve compatibility and flexibility with both MQTT and ZHA integrations. The main changes introduce conditional enabling of triggers based on which integration is available, and simplify action logic to reduce duplication and improve maintainability.

**Conditional Trigger Enablement and Logic Simplification:**

* Added `trigger_variables` to both blueprints, defining `mqtt_enabled` and `zha_enabled` flags to detect available integrations and conditionally enable triggers accordingly.
* Updated all relevant triggers in both blueprints to include an `enabled` field, which uses the new variables to ensure triggers are only active if the corresponding integration is available. 

**Action Logic Refactoring:**

* Simplified action sequences by removing redundant `choose` blocks and using the new `enabled` flags on `wait_for_trigger` steps, making the automation logic cleaner and easier to follow. 

These changes make the blueprints more robust and adaptable, ensuring they work seamlessly whether MQTT or ZHA integration is used.

